### PR TITLE
Fix tests

### DIFF
--- a/Big Sur Font Smoothing TogglerUITests/Big_Sur_Font_Smoothing_TogglerUITests.swift
+++ b/Big Sur Font Smoothing TogglerUITests/Big_Sur_Font_Smoothing_TogglerUITests.swift
@@ -63,7 +63,7 @@ class Big_Sur_Font_Smoothing_TogglerUITests: XCTestCase {
         bigSurFontSmoothingTogglerWindow.radioButtons["Enabled (default)"].click()
         logOutLaterButton.click()
         let enabledResult = try? runDefaultsCommand(with: getFontSmoothingStateArguments)
-        XCTAssert(enabledResult?.output == "2\n")
+        XCTAssert(enabledResult!.error.contains("The domain/default pair of (kCFPreferencesAnyApplication, AppleFontSmoothing) does not exist"))
     }
     
     private let getFontSmoothingStateArguments = ["-currentHost", "read", "Apple Global Domain", "AppleFontSmoothing"]

--- a/Font Smoothing Adjuster.xcodeproj/project.pbxproj
+++ b/Font Smoothing Adjuster.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		53A9B3C025E7B6560018E1FC /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 53A9B3BF25E7B6560018E1FC /* AppCenterAnalytics */; };
 		9308ED3925C32444008EC774 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9308ED3825C32444008EC774 /* Sparkle.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		9308ED3C25C3245C008EC774 /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9308ED3825C32444008EC774 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9323F17D27DA271100DB49C4 /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 9323F17C27DA271100DB49C4 /* AppCenterAnalytics */; };
+		9323F17F27DA271900DB49C4 /* AppCenterCrashes in Frameworks */ = {isa = PBXBuildFile; productRef = 9323F17E27DA271900DB49C4 /* AppCenterCrashes */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -119,6 +121,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9323F17D27DA271100DB49C4 /* AppCenterAnalytics in Frameworks */,
+				9323F17F27DA271900DB49C4 /* AppCenterCrashes in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -250,6 +254,8 @@
 			);
 			name = "Font Smoothing AdjusterUITests";
 			packageProductDependencies = (
+				9323F17C27DA271100DB49C4 /* AppCenterAnalytics */,
+				9323F17E27DA271900DB49C4 /* AppCenterCrashes */,
 			);
 			productName = "Big Sur Font Smoothing TogglerUITests";
 			productReference = 5350904A2562BD95005CCD39 /* Font Smoothing AdjusterUITests.xctest */;
@@ -746,6 +752,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 53A9B3BC25E7B6560018E1FC /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */;
 			productName = AppCenterAnalytics;
+		};
+		9323F17C27DA271100DB49C4 /* AppCenterAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 53A9B3BC25E7B6560018E1FC /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */;
+			productName = AppCenterAnalytics;
+		};
+		9323F17E27DA271900DB49C4 /* AppCenterCrashes */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 53A9B3BC25E7B6560018E1FC /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */;
+			productName = AppCenterCrashes;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Font Smoothing Adjuster.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Font Smoothing Adjuster.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/microsoft/appcenter-sdk-apple.git",
         "state": {
           "branch": null,
-          "revision": "484dead179e6d7edd534d0d7defdf65c14a5b426",
-          "version": "4.1.0"
+          "revision": "b84bc8a39ff04bc8d5ae7b4d230c171c562891aa",
+          "version": "4.4.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/microsoft/PLCrashReporter.git",
         "state": {
           "branch": null,
-          "revision": "de6b8f9db4b2a0aa859a5507550a70548e4da936",
-          "version": "1.8.1"
+          "revision": "6b27393cad517c067dceea85fadf050e70c4ceaa",
+          "version": "1.10.1"
         }
       }
     ]


### PR DESCRIPTION
The build phase for the tests were failing with the following error:

> No such module "AppCenterAnalytics"

Turns out that we needed to manually add dependencies to the test targets.

Source: https://github.com/facebook/facebook-ios-sdk/issues/1187

<img width="1111" alt="Screenshot 2022-03-10 at 12 34 43" src="https://user-images.githubusercontent.com/6968775/157664220-b69598bd-91a6-40ee-9900-bca98b804f0c.png">
