### PR TITLE
Fix crash getting font smoothing state

### DIFF
--- a/Big Sur Font Smoothing Toggler/FontSmoothingDefaults.swift
+++ b/Big Sur Font Smoothing Toggler/FontSmoothingDefaults.swift
@@ -35,17 +35,17 @@ class FontSmoothingDefaults {
         CFPreferencesSetValue(key, value, applicationID, userName, hostName)
         let result = CFPreferencesSynchronize(applicationID, userName, hostName)
         guard result else {
-            throw FontSmoothingDefaultsError.unknownError
+            throw FontSmoothingDefaultsError.snychronisingCFPreferencesFailed
         }
     }
     
     func getFontSmoothingState() throws -> FontSmoothingOptions {
         let value = CFPreferencesCopyAppValue(CFPreferencesConstants.key, CFPreferencesConstants.applicationID) as? Int ?? FontSmoothingOptions.enabled.rawValue
         
-            throw FontSmoothingDefaultsError.unknownError
         let fontSmoothingOptionValue = getValidFontSmoothingOptionValue(value)
         
         guard let option = FontSmoothingOptions(rawValue: fontSmoothingOptionValue) else {
+            throw FontSmoothingDefaultsError.invalidFontSmoothingOptionFound
         }
         
         return option
@@ -60,7 +60,8 @@ class FontSmoothingDefaults {
     }
     
     private enum FontSmoothingDefaultsError: Error {
-        case unknownError
+        case invalidFontSmoothingOptionFound
+        case snychronisingCFPreferencesFailed
     }
     
     private struct CFPreferencesConstants {

--- a/Big Sur Font Smoothing Toggler/FontSmoothingDefaults.swift
+++ b/Big Sur Font Smoothing Toggler/FontSmoothingDefaults.swift
@@ -42,11 +42,21 @@ class FontSmoothingDefaults {
     func getFontSmoothingState() throws -> FontSmoothingOptions {
         let value = CFPreferencesCopyAppValue(CFPreferencesConstants.key, CFPreferencesConstants.applicationID) as? Int ?? FontSmoothingOptions.enabled.rawValue
         
-        guard let option = FontSmoothingOptions(rawValue: value) else {
             throw FontSmoothingDefaultsError.unknownError
+        let fontSmoothingOptionValue = getValidFontSmoothingOptionValue(value)
+        
+        guard let option = FontSmoothingOptions(rawValue: fontSmoothingOptionValue) else {
         }
         
         return option
+    }
+    
+    private func getValidFontSmoothingOptionValue(_ value: Int) -> Int {
+        if value == 0 {
+            return FontSmoothingOptions.disabled.rawValue
+        } else {
+            return FontSmoothingOptions.enabled.rawValue
+        }
     }
     
     private enum FontSmoothingDefaultsError: Error {

--- a/Font Smoothing Adjuster.xcodeproj/project.pbxproj
+++ b/Font Smoothing Adjuster.xcodeproj/project.pbxproj
@@ -555,7 +555,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.3.1;
+				CURRENT_PROJECT_VERSION = 1.3.2;
 				DEVELOPMENT_TEAM = 4YNZUF26AM;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -567,7 +567,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bouncetechnologies.Font-Smoothing-Adjuster";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -583,7 +583,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.3.1;
+				CURRENT_PROJECT_VERSION = 1.3.2;
 				DEVELOPMENT_TEAM = 4YNZUF26AM;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -595,7 +595,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bouncetechnologies.Font-Smoothing-Adjuster";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Close #36 #37 

When we updated the application a few months ago, in #24 we removed a few options that didn't seem to impact the way the font smoothing was set. However, by removing these options, it seems like users who would have previously used one of the removed options were not able to use the application anymore, as the option set in the default mac setting would not match one of the UI options anymore.

These changes fix this behaviour to make sure that even when a user has previously set an option that isn't available anymore, the application doesn't crash on the user can select a new option.